### PR TITLE
Move config functions to 'opts' 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0  # Use the ref you want to point at
+  hooks:
+  - id: trailing-whitespace
+  - id: check-added-large-files
+
+- repo: https://github.com/JohnnyMorganz/StyLua
+  rev: v2.1.0
+  hooks:
+    - id: stylua # or stylua-system / stylua-github

--- a/nvim/lua/plugins/configs/cmp.lua
+++ b/nvim/lua/plugins/configs/cmp.lua
@@ -1,7 +1,5 @@
----@diagnostic disable: missing-fields
-local cmp = require("blink.cmp")
-
-cmp.setup({
+---@type blink.cmp.Config
+return {
     -- 'default' for mappings similar to built-in completion
     -- 'super-tab' for mappings similar to vscode (tab to accept, arrow keys to navigate)
     -- 'enter' for mappings similar to 'super-tab' but with 'enter' to accept
@@ -36,4 +34,4 @@ cmp.setup({
             end,
         },
     },
-})
+}

--- a/nvim/lua/plugins/configs/conform.lua
+++ b/nvim/lua/plugins/configs/conform.lua
@@ -1,15 +1,26 @@
-require("conform").setup({
+local M = {}
+
+M.opts = {
     notify_on_error = false,
     format_on_save = nil,
     formatters_by_ft = {
         lua = { "stylua" },
-        go = { "goimports", "gofmt"},
+        go = { "goimports", "gofmt" },
         python = { "isort", "ruff_format" },
         javascript = { "prettierd", "prettier", stop_after_first = true },
         typescript = { "prettierd", "prettier", stop_after_first = true },
     },
-})
+}
 
-vim.keymap.set("n", "<leader>cf", function()
-    require("conform").format({ async = true, lsp_fallback = true })
-end, { desc = "[C]ode [F]ormat buffer" })
+M.keys = {
+    {
+        "<leader>cf",
+        function()
+            require("conform").format({ async = true, lsp_fallback = true })
+        end,
+        "n",
+        desc = "[C]ode [F]ormat buffer",
+    },
+}
+
+return M

--- a/nvim/lua/plugins/configs/gitsigns.lua
+++ b/nvim/lua/plugins/configs/gitsigns.lua
@@ -1,4 +1,6 @@
-require("gitsigns").setup({
+---@diagnostic disable: missing-fields
+---@type Gitsigns.Config
+return {
     signs = {
         add = { text = "┃" },
         change = { text = "┃" },
@@ -109,4 +111,4 @@ require("gitsigns").setup({
         -- Text object
         map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>")
     end,
-})
+}

--- a/nvim/lua/plugins/configs/snacks.lua
+++ b/nvim/lua/plugins/configs/snacks.lua
@@ -1,6 +1,8 @@
-local snacks = require("snacks")
-snacks.setup({
-    ---@type snacks.Config
+local M = {}
+
+-- Config
+---@type snacks.Config
+M.opts = {
     bigfile = { enabled = true },
     indent = {
         enabled = true,
@@ -14,11 +16,20 @@ snacks.setup({
     scroll = { enabled = true },
     statuscolumn = { enabled = true },
     terminal = {},
-})
+}
 
 -- Keymaps
-local function toggle_term()
-    snacks.terminal.open()
-    vim.api.nvim_win_set_height(0, 15)
-end
-vim.keymap.set("n", "<leader>tt", toggle_term, { desc = "[T]oggle [T]erminal}" })
+---@type LazyKeysSpec[]
+M.keys = {
+    {
+        "<leader>tt",
+        function()
+            require("snacks").terminal.open()
+            vim.api.nvim_win_set_height(0, 15)
+        end,
+        "n",
+        desc = "[T]oggle [T]erminal}",
+    },
+}
+
+return M

--- a/nvim/lua/plugins/configs/which_key.lua
+++ b/nvim/lua/plugins/configs/which_key.lua
@@ -1,22 +1,24 @@
-local wk = require("which-key")
-wk.setup()
+---@class wk.Opts
+local M = {
+    -- Document existing key chains
+    spec = {
+        { "<leader>c", group = "[C]ode" },
+        { "<leader>c_", hidden = true },
+        { "<leader>d", group = "[D]ocument" },
+        { "<leader>d_", hidden = true },
+        { "<leader>h", group = "Git [H]unk" },
+        { "<leader>h_", hidden = true },
+        { "<leader>r", group = "[R]ename" },
+        { "<leader>r_", hidden = true },
+        { "<leader>s", group = "[S]earch" },
+        { "<leader>s_", hidden = true },
+        { "<leader>t", group = "[T]oggle" },
+        { "<leader>t_", hidden = true },
+        { "<leader>w", group = "[W]orkspace" },
+        { "<leader>w_", hidden = true },
+        -- visual mode
+        { "<leader>h", desc = "Git [H]unk", mode = "v" },
+    },
+}
 
--- Document existing key chains
-wk.add({
-    { "<leader>c", group = "[C]ode" },
-    { "<leader>c_", hidden = true },
-    { "<leader>d", group = "[D]ocument" },
-    { "<leader>d_", hidden = true },
-    { "<leader>h", group = "Git [H]unk" },
-    { "<leader>h_", hidden = true },
-    { "<leader>r", group = "[R]ename" },
-    { "<leader>r_", hidden = true },
-    { "<leader>s", group = "[S]earch" },
-    { "<leader>s_", hidden = true },
-    { "<leader>t", group = "[T]oggle" },
-    { "<leader>t_", hidden = true },
-    { "<leader>w", group = "[W]orkspace" },
-    { "<leader>w_", hidden = true },
-    -- visual mode
-    { "<leader>h", desc = "Git [H]unk", mode = "v" },
-})
+return M

--- a/nvim/lua/plugins/imports/coding.lua
+++ b/nvim/lua/plugins/imports/coding.lua
@@ -43,8 +43,7 @@ return {
     { -- Autoformat
         "stevearc/conform.nvim",
         lazy = false,
-        config = function()
-            require("plugins.configs.conform")
-        end,
+        opts = require("plugins.configs.conform").opts,
+        keys = require("plugins.configs.conform").keys,
     },
 }

--- a/nvim/lua/plugins/imports/coding.lua
+++ b/nvim/lua/plugins/imports/coding.lua
@@ -24,16 +24,11 @@ return {
     -- Autocompletion
     {
         "saghen/blink.cmp",
-        -- use a release tag to download pre-built binaries
         version = "v1.*",
         lazy = false, -- lazy loading handled internally
-        dependencies = "rafamadriz/friendly-snippets",
-        -- allows extending the providers array elsewhere in your config
-        -- without having to redefine it
+        dependencies = { "rafamadriz/friendly-snippets" },
+        opts = require("plugins.configs.cmp"),
         opts_extend = { "sources.default" },
-        config = function()
-            require("plugins.configs.cmp")
-        end,
     },
 
     { -- Linting

--- a/nvim/lua/plugins/imports/coding.lua
+++ b/nvim/lua/plugins/imports/coding.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     -- "gc" to comment visual regions/lines
     { "numToStr/Comment.nvim", opts = {} },

--- a/nvim/lua/plugins/imports/colorscheme.lua
+++ b/nvim/lua/plugins/imports/colorscheme.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     -- catppuccin
     {

--- a/nvim/lua/plugins/imports/editor.lua
+++ b/nvim/lua/plugins/imports/editor.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     -- Fuzzy Finder (files, lsp, etc)
     {

--- a/nvim/lua/plugins/imports/fs.lua
+++ b/nvim/lua/plugins/imports/fs.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     {
         "stevearc/oil.nvim",

--- a/nvim/lua/plugins/imports/helpers.lua
+++ b/nvim/lua/plugins/imports/helpers.lua
@@ -2,9 +2,7 @@ return {
     -- Show key bindings
     {
         "folke/which-key.nvim",
-        config = function()
-            require("plugins.configs.which_key")
-        end,
+        opts = require("plugins.configs.which_key"),
     },
     -- QoL improvements
     {
@@ -13,6 +11,6 @@ return {
         lazy = false,
         config = function()
             require("plugins.configs.snacks")
-        end
+        end,
     },
 }

--- a/nvim/lua/plugins/imports/helpers.lua
+++ b/nvim/lua/plugins/imports/helpers.lua
@@ -10,8 +10,7 @@ return {
         "folke/snacks.nvim",
         priority = 1000,
         lazy = false,
-        config = function()
-            require("plugins.configs.snacks")
-        end,
+        opts = require("plugins.configs.snacks").opts,
+        keys = require("plugins.configs.snacks").keys,
     },
 }

--- a/nvim/lua/plugins/imports/helpers.lua
+++ b/nvim/lua/plugins/imports/helpers.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     -- Show key bindings
     {

--- a/nvim/lua/plugins/imports/lsp.lua
+++ b/nvim/lua/plugins/imports/lsp.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     -- NOTE: This is where your plugins related to LSP can be installed.
     --  The configuration is done below. Search for lspconfig to find it below.

--- a/nvim/lua/plugins/imports/notes.lua
+++ b/nvim/lua/plugins/imports/notes.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     -- Zettelkasten note-taking
     {

--- a/nvim/lua/plugins/imports/treesitter.lua
+++ b/nvim/lua/plugins/imports/treesitter.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     -- Highlight, edit, and navigate code
     {

--- a/nvim/lua/plugins/imports/vcs.lua
+++ b/nvim/lua/plugins/imports/vcs.lua
@@ -1,3 +1,4 @@
+---@type LazyPluginSpec[]
 return {
     -- Adds git related signs to the gutter, as well as utilities for managing changes
     {

--- a/nvim/lua/plugins/imports/vcs.lua
+++ b/nvim/lua/plugins/imports/vcs.lua
@@ -3,9 +3,7 @@ return {
     -- Adds git related signs to the gutter, as well as utilities for managing changes
     {
         "lewis6991/gitsigns.nvim",
-        config = function()
-            require("plugins.configs.gitsigns")
-        end,
+        opts = require("plugins.configs.gitsigns"),
     },
     {
         "kdheepak/lazygit.nvim",


### PR DESCRIPTION
As described in the [lazy.nvim docs](https://lazy.folke.io/spec#spec-setup), it is *not* recommended to use the `config` property of a plugin import object. This branch adjusts the imports to use `opts` instead of `config` for the most obvious cases. For some plugins, the `config` setting must remain a special plugin setup.

Also adds a `pre-commit` hook config and type annotation for the import files