### PR TITLE
Switching from Telescope to Snacks.picker

### DIFF
--- a/nvim/lua/plugins/configs/lspconfig.lua
+++ b/nvim/lua/plugins/configs/lspconfig.lua
@@ -15,27 +15,13 @@ vim.api.nvim_create_autocmd("LspAttach", {
         map("<leader>rn", vim.lsp.buf.rename, "[R]e[n]ame")
         map("<leader>ca", vim.lsp.buf.code_action, "[C]ode [A]ction")
 
-        map("gd", vim.lsp.buf.definition, "[G]oto [D]efinition")
-        map("gr", require("telescope.builtin").lsp_references, "[G]oto [R]eferences")
-        map("gI", require("telescope.builtin").lsp_implementations, "[G]oto [I]mplementation")
         map("<leader>D", vim.lsp.buf.type_definition, "Type [D]efinition")
-        map(
-            "<leader>ds",
-            require("telescope.builtin").lsp_document_symbols,
-            "[D]ocument [S]ymbols"
-        )
-        map(
-            "<leader>ws",
-            require("telescope.builtin").lsp_dynamic_workspace_symbols,
-            "[W]orkspace [S]ymbols"
-        )
 
         -- See `:help K` for why this keymap
         map("K", vim.lsp.buf.hover, "Hover Documentation")
         map("<leader>k", vim.lsp.buf.signature_help, "Signature Documentation")
 
         -- Lesser used LSP functionality
-        map("gD", vim.lsp.buf.declaration, "[G]oto [D]eclaration")
         map("<leader>wa", vim.lsp.buf.add_workspace_folder, "[W]orkspace [A]dd Folder")
         map("<leader>wr", vim.lsp.buf.remove_workspace_folder, "[W]orkspace [R]emove Folder")
         map("<leader>wl", function()
@@ -77,8 +63,11 @@ require("neodev").setup()
 --  With blink.cmp, Neovim has *more* capabilities which are communicated to the LSP servers.
 --  Explanation from TJ: https://youtu.be/m8C0Cq9Uv9o?t=1275
 local capabilities = vim.lsp.protocol.make_client_capabilities()
-capabilities =
-    vim.tbl_deep_extend("force", capabilities, require('blink.cmp').get_lsp_capabilities(capabilities))
+capabilities = vim.tbl_deep_extend(
+    "force",
+    capabilities,
+    require("blink.cmp").get_lsp_capabilities(capabilities)
+)
 
 -- Ensure language servers and tools are installed via Mason
 require("mason").setup()

--- a/nvim/lua/plugins/configs/snacks.lua
+++ b/nvim/lua/plugins/configs/snacks.lua
@@ -16,6 +16,7 @@ M.opts = {
     scroll = { enabled = true },
     statuscolumn = { enabled = true },
     terminal = {},
+    picker = {},
 }
 
 -- Keymaps

--- a/nvim/lua/plugins/configs/snacks.lua
+++ b/nvim/lua/plugins/configs/snacks.lua
@@ -22,6 +22,7 @@ M.opts = {
 -- Keymaps
 ---@type LazyKeysSpec[]
 M.keys = {
+    -- snacks.terminal
     {
         "<leader>tt",
         function()
@@ -31,6 +32,66 @@ M.keys = {
         "n",
         desc = "[T]oggle [T]erminal}",
     },
+    -- snacks.picker
+    -- stylua: ignore start
+    -- Top Pickers & Explorer
+    -- { "<leader><space>", function() Snacks.picker.smart() end, desc = "Smart Find Files" },
+    { "<leader><space>", function() Snacks.picker.buffers() end, desc = "Buffers" },
+    { "<leader>/", function() Snacks.picker.grep() end, desc = "Grep" },
+    { "<leader>:", function() Snacks.picker.command_history() end, desc = "Command History" },
+    { "<leader>n", function() Snacks.picker.notifications() end, desc = "Notification History" },
+    -- { "<leader>e", function() Snacks.explorer() end, desc = "File Explorer" },
+    -- find
+    { "<leader>fb", function() Snacks.picker.buffers() end, desc = "[F]ind [B]uffers" },
+    { "<leader>fc", function() Snacks.picker.files({ cwd = vim.fn.stdpath("config") }) end, desc = "[F]ind [C]onfig File" },
+    { "<leader>ff", function() Snacks.picker.files() end, desc = "[F]ind [F]iles" },
+    { "<leader>fg", function() Snacks.picker.git_files() end, desc = "[F]ind [G]it Files" },
+    { "<leader>fp", function() Snacks.picker.projects() end, desc = "[F]ind [P]rojects" },
+    { "<leader>fr", function() Snacks.picker.recent() end, desc = "[F]ind [R]ecent" },
+    -- git
+    { "<leader>gb", function() Snacks.picker.git_branches() end, desc = "[G]it [B]ranches" },
+    { "<leader>gl", function() Snacks.picker.git_log() end, desc = "[G]it [L]og" },
+    { "<leader>gL", function() Snacks.picker.git_log_line() end, desc = "[G]it [L]og Line" },
+    { "<leader>gs", function() Snacks.picker.git_status() end, desc = "[G]it Status" },
+    { "<leader>gS", function() Snacks.picker.git_stash() end, desc = "[G]it [S]tash" },
+    { "<leader>gd", function() Snacks.picker.git_diff() end, desc = "[G]it [D]iff (Hunks)" },
+    { "<leader>gf", function() Snacks.picker.git_log_file() end, desc = "[G]it Log [F]ile" },
+    -- Grep
+    { "<leader>sb", function() Snacks.picker.lines() end, desc = "[B]uffer Lines" },
+    { "<leader>sB", function() Snacks.picker.grep_buffers() end, desc = "Grep Open [B]uffers" },
+    { "<leader>sg", function() Snacks.picker.grep() end, desc = "[G]rep" },
+    { "<leader>sw", function() Snacks.picker.grep_word() end, desc = "Visual selection or [w]ord", mode = { "n", "x" } },
+    -- search
+    { '<leader>s"', function() Snacks.picker.registers() end, desc = "Registers" },
+    { '<leader>s/', function() Snacks.picker.search_history() end, desc = "[S]earch History" },
+    { "<leader>sa", function() Snacks.picker.autocmds() end, desc = "[A]utocmds" },
+    { "<leader>sb", function() Snacks.picker.lines() end, desc = "[B]uffer Lines" },
+    { "<leader>sc", function() Snacks.picker.command_history() end, desc = "[C]ommand History" },
+    { "<leader>sC", function() Snacks.picker.commands() end, desc = "[C]ommands" },
+    { "<leader>sd", function() Snacks.picker.diagnostics() end, desc = "[D]iagnostics" },
+    { "<leader>sD", function() Snacks.picker.diagnostics_buffer() end, desc = "Buffer [D]iagnostics" },
+    { "<leader>sh", function() Snacks.picker.help() end, desc = "[H]elp Pages" },
+    { "<leader>sH", function() Snacks.picker.highlights() end, desc = "[H]ighlights" },
+    { "<leader>si", function() Snacks.picker.icons() end, desc = "[I]cons" },
+    { "<leader>sj", function() Snacks.picker.jumps() end, desc = "[J]umps" },
+    { "<leader>sk", function() Snacks.picker.keymaps() end, desc = "[K]eymaps" },
+    { "<leader>sl", function() Snacks.picker.loclist() end, desc = "[L]ocation List" },
+    { "<leader>sm", function() Snacks.picker.marks() end, desc = "[M]arks" },
+    { "<leader>sM", function() Snacks.picker.man() end, desc = "[M]an Pages" },
+    { "<leader>sp", function() Snacks.picker.lazy() end, desc = "[S]earch for [P]lugin Spec" },
+    { "<leader>sq", function() Snacks.picker.qflist() end, desc = "[Q]uickfix List" },
+    { "<leader>sR", function() Snacks.picker.resume() end, desc = "[R]esume" },
+    { "<leader>su", function() Snacks.picker.undo() end, desc = "[U]ndo History" },
+    { "<leader>uC", function() Snacks.picker.colorschemes() end, desc = "[C]olorschemes" },
+    -- LSP
+    { "gd", function() Snacks.picker.lsp_definitions() end, desc = "[G]oto [D]efinition" },
+    { "gD", function() Snacks.picker.lsp_declarations() end, desc = "[G]oto [D]eclaration" },
+    { "gr", function() Snacks.picker.lsp_references() end, nowait = true, desc = "[R]eferences" },
+    { "gI", function() Snacks.picker.lsp_implementations() end, desc = "[G]oto [I]mplementation" },
+    { "gy", function() Snacks.picker.lsp_type_definitions() end, desc = "[G]oto T[y]pe Definition" },
+    { "<leader>ss", function() Snacks.picker.lsp_symbols() end, desc = "LSP [S]ymbols" },
+    { "<leader>sS", function() Snacks.picker.lsp_workspace_symbols() end, desc = "LSP Workspace [S]ymbols" },
+    --stylua: ignore end
 }
 
 return M

--- a/nvim/lua/plugins/configs/telescope.lua
+++ b/nvim/lua/plugins/configs/telescope.lua
@@ -16,33 +16,33 @@ pcall(require("telescope").load_extension, "fzf")
 
 -- Set keymaps
 -- See `:help telescope.builtin`
-local builtin = require("telescope.builtin")
-vim.keymap.set("n", "<leader>?", builtin.oldfiles, { desc = "[?] Find recently opened files" })
-vim.keymap.set("n", "<leader><space>", builtin.buffers, { desc = "[ ] Find existing buffers" })
-vim.keymap.set("n", "<leader><leader>", builtin.buffers, { desc = "[ ] Find existing buffers" })
-vim.keymap.set("n", "<leader>/", function()
-    -- You can pass additional configuration to telescope to change theme, layout, etc.
-    builtin.current_buffer_fuzzy_find(require("telescope.themes").get_dropdown({
-        winblend = 10,
-        previewer = false,
-    }))
-end, { desc = "[/] Fuzzily search in current buffer" })
-
-vim.keymap.set("n", "<leader>gf", builtin.git_files, { desc = "Search [G]it [F]iles" })
-vim.keymap.set("n", "<leader>sf", builtin.find_files, { desc = "[S]earch [F]iles" })
-vim.keymap.set("n", "<leader>sh", builtin.help_tags, { desc = "[S]earch [H]elp" })
-vim.keymap.set("n", "<leader>sk", builtin.keymaps, { desc = "[S]earch [K]eymaps" })
-vim.keymap.set("n", "<leader>sw", builtin.grep_string, { desc = "[S]earch current [W]ord" })
-vim.keymap.set("n", "<leader>sg", builtin.live_grep, { desc = "[S]earch by [G]rep" })
-vim.keymap.set("n", "<leader>sd", builtin.diagnostics, { desc = "[S]earch [D]iagnostics" })
-vim.keymap.set("n", "<leader>sr", builtin.resume, { desc = "[S]earch [R]esume" })
-vim.keymap.set("n", "<leader>ss", builtin.builtin, { desc = "[S]earch [S]elect Telescope" })
-vim.keymap.set(
-    "n",
-    "<leader>s.",
-    builtin.oldfiles,
-    { desc = '[S]earch Recent Files ("." for repeat)' }
-)
-vim.keymap.set("n", "<leader>so", function()
-    builtin.lsp_document_symbols({ symbols = { "class", "function", "method" } })
-end, { desc = "[S]earch [O]bjects (class and function)" })
+-- local builtin = require("telescope.builtin")
+-- vim.keymap.set("n", "<leader>?", builtin.oldfiles, { desc = "[?] Find recently opened files" })
+-- vim.keymap.set("n", "<leader><space>", builtin.buffers, { desc = "[ ] Find existing buffers" })
+-- vim.keymap.set("n", "<leader><leader>", builtin.buffers, { desc = "[ ] Find existing buffers" })
+-- vim.keymap.set("n", "<leader>/", function()
+--     -- You can pass additional configuration to telescope to change theme, layout, etc.
+--     builtin.current_buffer_fuzzy_find(require("telescope.themes").get_dropdown({
+--         winblend = 10,
+--         previewer = false,
+--     }))
+-- end, { desc = "[/] Fuzzily search in current buffer" })
+--
+-- vim.keymap.set("n", "<leader>gf", builtin.git_files, { desc = "Search [G]it [F]iles" })
+-- vim.keymap.set("n", "<leader>sf", builtin.find_files, { desc = "[S]earch [F]iles" })
+-- vim.keymap.set("n", "<leader>sh", builtin.help_tags, { desc = "[S]earch [H]elp" })
+-- vim.keymap.set("n", "<leader>sk", builtin.keymaps, { desc = "[S]earch [K]eymaps" })
+-- vim.keymap.set("n", "<leader>sw", builtin.grep_string, { desc = "[S]earch current [W]ord" })
+-- vim.keymap.set("n", "<leader>sg", builtin.live_grep, { desc = "[S]earch by [G]rep" })
+-- vim.keymap.set("n", "<leader>sd", builtin.diagnostics, { desc = "[S]earch [D]iagnostics" })
+-- vim.keymap.set("n", "<leader>sr", builtin.resume, { desc = "[S]earch [R]esume" })
+-- vim.keymap.set("n", "<leader>ss", builtin.builtin, { desc = "[S]earch [S]elect Telescope" })
+-- vim.keymap.set(
+--     "n",
+--     "<leader>s.",
+--     builtin.oldfiles,
+--     { desc = '[S]earch Recent Files ("." for repeat)' }
+-- )
+-- vim.keymap.set("n", "<leader>so", function()
+--     builtin.lsp_document_symbols({ symbols = { "class", "function", "method" } })
+-- end, { desc = "[S]earch [O]bjects (class and function)" })

--- a/nvim/lua/plugins/configs/treesitter.lua
+++ b/nvim/lua/plugins/configs/treesitter.lua
@@ -5,12 +5,16 @@ require("nvim-treesitter.configs").setup({
     -- Add languages to be installed here that you want installed for treesitter
     ensure_installed = {
         "bash",
+        "css",
         "go",
         "html",
         "javascript",
+        "latex",
         "lua",
         "python",
+        "regex",
         "rust",
+        "scss",
         "tsx",
         "typescript",
         "vimdoc",

--- a/nvim/lua/plugins/configs/zk.lua
+++ b/nvim/lua/plugins/configs/zk.lua
@@ -1,5 +1,5 @@
 require("zk").setup({
-    picker = "telescope",
+    picker = "snacks_picker",
 })
 
 vim.keymap.set("n", "<leader>zn", function()


### PR DESCRIPTION
This branch concerns switching from `telescope.nvim` to `snacks.picker`.

#### Changelog
- **feat(nvim): use snacks.picker**
- **refactor(nvim): deactivate or remove telescope keymaps**
- **refactor(nvim): enable snacks.picker keymaps**
- **refactor(nvim): use snacks.picker for zk**
- **refactor(nvim): ensure more installed languages for treesitter**
